### PR TITLE
Add ROS2 build steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ This repository includes a simple ROS 2 example for saving images from an Intel
 - `cv_bridge`
 - OpenCV
 
+## Building
+
+After cloning this repository into a ROS 2 workspace, build the package and
+source the environment:
+
+```bash
+colcon build
+source install/setup.bash
+```
+
 ## Usage
 1. Launch the RealSense camera node (as you already do):
    ```bash
@@ -23,5 +33,16 @@ This repository includes a simple ROS 2 example for saving images from an Intel
    ros2 run realsense_image_saver capture_images --ros-args \
        -p image_topic:=/my/image/topic -p output_dir:=/path/to/save
    ```
+
+To capture images less frequently, set `save_interval_sec` to the desired number
+of seconds. For example, to save one image every 30 seconds:
+
+```bash
+ros2 run realsense_image_saver capture_images --ros-args \
+    -p save_interval_sec:=30
+```
+
+`ros2 run` requires that the package has been built and that the environment
+is sourced, as shown in the *Building* section above.
 
 The captured images will be stored sequentially as `frame_XXXXXX.png`.

--- a/realsense_image_saver/realsense_image_saver/capture_images.py
+++ b/realsense_image_saver/realsense_image_saver/capture_images.py
@@ -17,23 +17,42 @@ class ImageSaver(Node):
         super().__init__('image_saver')
         self.declare_parameter('image_topic', '/color/image_raw')
         self.declare_parameter('output_dir', 'images')
+        self.declare_parameter('save_interval_sec', 0.0)
 
-        image_topic = self.get_parameter('image_topic').get_parameter_value().string_value
-        self.output_dir = self.get_parameter('output_dir').get_parameter_value().string_value
+        image_topic = (
+            self.get_parameter('image_topic').get_parameter_value().string_value
+        )
+        self.output_dir = (
+            self.get_parameter('output_dir').get_parameter_value().string_value
+        )
+        self.save_interval = (
+            self.get_parameter('save_interval_sec').get_parameter_value().double_value
+        )
+        self.last_save_time = self.get_clock().now()
 
         os.makedirs(self.output_dir, exist_ok=True)
         self.bridge = CvBridge()
-        self.subscription = self.create_subscription(Image, image_topic, self.listener_callback, 10)
+        self.subscription = self.create_subscription(
+            Image, image_topic, self.listener_callback, 10
+        )
         self.frame_id = 0
         self.get_logger().info(f'Subscribed to {image_topic}; saving to {self.output_dir}')
 
     def listener_callback(self, msg: Image) -> None:
         try:
+            now = self.get_clock().now()
+            if (
+                self.save_interval > 0
+                and (now - self.last_save_time).nanoseconds
+                < self.save_interval * 1e9
+            ):
+                return
             cv_image = self.bridge.imgmsg_to_cv2(msg, desired_encoding='bgr8')
             filename = os.path.join(self.output_dir, f"frame_{self.frame_id:06d}.png")
             cv2.imwrite(filename, cv_image)
             self.get_logger().debug(f'Saved image {filename}')
             self.frame_id += 1
+            self.last_save_time = now
         except Exception as exc:
             self.get_logger().error(f'Failed to save image: {exc}')
 


### PR DESCRIPTION
## Summary
- document building and sourcing the environment with `colcon build`
- mention that `ros2 run` requires the environment to be sourced
- allow throttling image capture frequency with a new `save_interval_sec` parameter

## Testing
- `python3 -m py_compile realsense_image_saver/realsense_image_saver/capture_images.py`
- `pytest -q`
- `colcon build --packages-select realsense_image_saver` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c13437de0832ebb5016b1d534c259